### PR TITLE
Added Probe Tool to list of available tools when Manual Tool Change Plugin is enable

### DIFF
--- a/src/NcSender.Server/Plugins/PluginManager.cs
+++ b/src/NcSender.Server/Plugins/PluginManager.cs
@@ -622,7 +622,15 @@ public class PluginManager : IPluginManager
                 toolSettings["count"] = count;
                 toolSettings["manual"] = true;
                 toolSettings["tls"] = true;
-                toolSettings["probe"] = false;
+                if (settings.TryGetValue("addProbe", out var addProbe))
+                {
+                    toolSettings["probe"] = JsonValue.Create(Convert.ToBoolean(addProbe.ToString()));
+                }
+                else
+                {
+                    toolSettings["probe"] = false;
+                }
+                
             }
             else
             {


### PR DESCRIPTION
I have made some changes to the Manual Tool Changer Plugin to be able to add the Probe to the List of Tools. (Seperate Pull request to add this feature to Plugin Repository)
When I save the settings the Probe Tool is available in the list, however, when I close and Open ncSender, the Probe tool goes missing until I open and save the Plugin again.
I found this was due to the PluginManager when it loads up the Plugins, it doesnt read the settings file from the Plugin to Enable/Disable the Probe Tool. It always sets this to "False".

I just added some code to get the setting from the Plugin, and if it exists, then update the ncSender setting accordingly.

This was built and tested as working successfully