### PR TITLE
Fix center-probe G-code syntax for FluidNC

### DIFF
--- a/src/NcSender.Server/Probing/Strategies/ThreeDProbeStrategy.cs
+++ b/src/NcSender.Server/Probing/Strategies/ThreeDProbeStrategy.cs
@@ -203,7 +203,10 @@ public static class ThreeDProbeStrategy
         code.Add($"G0 X-{bounce}");
         code.Add($"G38.2 X3 F{slowFeed}");
         code.Add("#<X2> = #5061");
-        code.Add("G0 X-[[#<X2>-#<X1>]/2]");
+        // FluidNC rejects "G0 X-[expr]" (leading minus on a bracketed
+        // expression — invalid per LinuxCNC G-code spec). Swap operands so the
+        // result is naturally negative; grblHAL accepts both forms. (issue #55)
+        code.Add("G0 X[[#<X1>-#<X2>]/2]");
 
         if (safeRapidY > 0)
             code.Add($"G38.3 Y-{F(safeRapidY)} F#<RAPID_SEARCH>");
@@ -221,7 +224,7 @@ public static class ThreeDProbeStrategy
         code.Add($"G0 Y-{bounce}");
         code.Add($"G38.2 Y3 F{slowFeed}");
         code.Add("#<Y2> = #5062");
-        code.Add("G0 Y-[[#<Y2>-#<Y1>]/2]");
+        code.Add("G0 Y[[#<Y1>-#<Y2>]/2]");
         code.Add("G10 L20 X0 Y0");
         code.Add($"G0 Z{F(zPlunge + 4)}");
         code.Add("G90");
@@ -284,7 +287,7 @@ public static class ThreeDProbeStrategy
         code.Add($"G0 X{bounce}");
         code.Add($"G0 Z{F(zHop)}");
         code.Add($"G0 X-{bounce}");
-        code.Add("G0 X-[[#<X2>-#<X1>]/2]");
+        code.Add("G0 X[[#<X1>-#<X2>]/2]");
 
         if (safeRapidY > 0)
             code.Add($"G38.3 Y-{F(safeRapidY)} F#<RAPID_SEARCH>");
@@ -310,7 +313,7 @@ public static class ThreeDProbeStrategy
         code.Add($"G0 Y{bounce}");
         code.Add($"G0 Z{F(zHop)}");
         code.Add($"G0 Y-{bounce}");
-        code.Add("G0 Y-[[#<Y2>-#<Y1>]/2]");
+        code.Add("G0 Y[[#<Y1>-#<Y2>]/2]");
         code.Add("G10 L20 X0 Y0");
         code.Add("G90");
         code.Add("G[#<return_units>]");

--- a/tests/NcSender.Server.Tests/ThreeDProbeStrategyTests.cs
+++ b/tests/NcSender.Server.Tests/ThreeDProbeStrategyTests.cs
@@ -1,0 +1,146 @@
+using System.Text.RegularExpressions;
+using NcSender.Server.Probing.Strategies;
+
+namespace NcSender.Server.Tests;
+
+public class ThreeDProbeStrategyTests
+{
+    // FluidNC follows the LinuxCNC G-code spec, which rejects a leading minus
+    // on a bracketed expression after an axis letter (e.g. "X-[expr]"). The
+    // expression must be either a number — which may itself be negative — or a
+    // bracketed group, but not a mixture. grblHAL accepts the bad form, which
+    // is why issue #55 only surfaced on FluidNC.
+    private static readonly Regex BadFluidNcPattern = new(@"\b[XYZ]-\[", RegexOptions.Compiled);
+
+    public static IEnumerable<object[]> CenterRoutines()
+    {
+        yield return new object[] { "Inner", ThreeDProbeStrategy.GetCenterInnerRoutine(30, 30) };
+        yield return new object[] { "Outer", ThreeDProbeStrategy.GetCenterOuterRoutine(30, 30) };
+    }
+
+    [Theory]
+    [MemberData(nameof(CenterRoutines))]
+    public void CenterRoutine_DoesNotEmitFluidNcIncompatibleSyntax(string label, List<string> routine)
+    {
+        var offenders = routine
+            .Where(line => BadFluidNcPattern.IsMatch(line))
+            .ToList();
+
+        Assert.True(
+            offenders.Count == 0,
+            $"{label} routine emits {offenders.Count} FluidNC-incompatible line(s) " +
+            $"(leading minus on a bracketed expression after axis letter):\n" +
+            string.Join("\n", offenders));
+    }
+
+    [Theory]
+    [MemberData(nameof(CenterRoutines))]
+    public void CenterRoutine_CapturesBothProbePointsPerAxis(string label, List<string> routine)
+    {
+        // The routine must capture two probe points per axis into named
+        // parameters #<X1>/#<X2>/#<Y1>/#<Y2>. Don't change the variable
+        // contract without coordinating with the midpoint move expression.
+        Assert.Contains(routine, line => line.Contains("#<X1> = #5061"));
+        Assert.Contains(routine, line => line.Contains("#<X2> = #5061"));
+        Assert.Contains(routine, line => line.Contains("#<Y1> = #5062"));
+        Assert.Contains(routine, line => line.Contains("#<Y2> = #5062"));
+    }
+
+    [Theory]
+    [MemberData(nameof(CenterRoutines))]
+    public void CenterRoutine_MidpointMoveEvaluatesToHalfDistance(string label, List<string> routine)
+    {
+        // After the X probes finish at X2, a relative move must take the
+        // tool to the midpoint between X1 and X2. The signed offset is
+        // (X1 - X2) / 2 — substitute concrete values and evaluate to verify
+        // the math, regardless of how the expression is written textually.
+        AssertMidpointMove(routine, axis: 'X', x1: 0, x2: 10, expected: -5, label: label);
+        AssertMidpointMove(routine, axis: 'Y', x1: 0, x2: 10, expected: -5, label: label);
+
+        // Sanity check: an asymmetric capture still produces the right offset.
+        AssertMidpointMove(routine, axis: 'X', x1: 4, x2: 14, expected: -5, label: label);
+    }
+
+    private static void AssertMidpointMove(List<string> routine, char axis, double x1, double x2, double expected, string label)
+    {
+        // Find the midpoint move: a G0 line referencing both #<{axis}1> and #<{axis}2>.
+        var line = routine.FirstOrDefault(l =>
+            l.Contains($"#<{axis}1>", StringComparison.OrdinalIgnoreCase) &&
+            l.Contains($"#<{axis}2>", StringComparison.OrdinalIgnoreCase) &&
+            l.TrimStart().StartsWith("G0 ", StringComparison.OrdinalIgnoreCase));
+
+        Assert.NotNull(line);
+
+        // Extract the expression after the axis letter.
+        var idx = line!.IndexOf(axis, StringComparison.OrdinalIgnoreCase);
+        Assert.True(idx >= 0, $"{label}: no {axis} argument in midpoint line: {line}");
+        var argument = line[(idx + 1)..];
+
+        // Substitute parameters and convert LinuxCNC bracket syntax to standard
+        // arithmetic, then evaluate.
+        var expr = argument
+            .Replace($"#<{axis}1>", x1.ToString(System.Globalization.CultureInfo.InvariantCulture))
+            .Replace($"#<{axis}2>", x2.ToString(System.Globalization.CultureInfo.InvariantCulture))
+            .Replace('[', '(')
+            .Replace(']', ')');
+
+        var actual = EvaluateArithmetic(expr);
+        Assert.Equal(expected, actual, precision: 6);
+    }
+
+    // Minimal arithmetic evaluator for "(", ")", unary "-", "+", "-", "*", "/".
+    // Sufficient for the midpoint expressions; intentionally not a general
+    // G-code expression engine.
+    private static double EvaluateArithmetic(string expr)
+    {
+        var pos = 0;
+        var result = ParseExpression(expr.Replace(" ", ""), ref pos);
+        if (pos != expr.Replace(" ", "").Length)
+            throw new InvalidOperationException($"Unparsed tail at {pos}: '{expr}'");
+        return result;
+    }
+
+    private static double ParseExpression(string s, ref int pos)
+    {
+        var value = ParseTerm(s, ref pos);
+        while (pos < s.Length && (s[pos] == '+' || s[pos] == '-'))
+        {
+            var op = s[pos++];
+            var rhs = ParseTerm(s, ref pos);
+            value = op == '+' ? value + rhs : value - rhs;
+        }
+        return value;
+    }
+
+    private static double ParseTerm(string s, ref int pos)
+    {
+        var value = ParseFactor(s, ref pos);
+        while (pos < s.Length && (s[pos] == '*' || s[pos] == '/'))
+        {
+            var op = s[pos++];
+            var rhs = ParseFactor(s, ref pos);
+            value = op == '*' ? value * rhs : value / rhs;
+        }
+        return value;
+    }
+
+    private static double ParseFactor(string s, ref int pos)
+    {
+        if (pos < s.Length && s[pos] == '+') { pos++; return ParseFactor(s, ref pos); }
+        if (pos < s.Length && s[pos] == '-') { pos++; return -ParseFactor(s, ref pos); }
+        if (pos < s.Length && s[pos] == '(')
+        {
+            pos++;
+            var v = ParseExpression(s, ref pos);
+            if (pos >= s.Length || s[pos] != ')')
+                throw new InvalidOperationException($"Expected ')' at {pos} in '{s}'");
+            pos++;
+            return v;
+        }
+        var start = pos;
+        while (pos < s.Length && (char.IsDigit(s[pos]) || s[pos] == '.'))
+            pos++;
+        if (start == pos) throw new InvalidOperationException($"Expected number at {pos} in '{s}'");
+        return double.Parse(s[start..pos], System.Globalization.CultureInfo.InvariantCulture);
+    }
+}


### PR DESCRIPTION
Fixes #55

## Summary
- Center-probe routines emitted `G0 X-[[#<X2>-#<X1>]/2]` for the midpoint move. FluidNC follows the LinuxCNC G-code spec and rejects a leading minus on a bracketed expression. grblHAL is lenient and accepts it, so the bug only surfaced for FluidNC users.
- Fix: swap operands → `G0 X[[#<X1>-#<X2>]/2]`. Same value, valid on both firmwares. Applied to inner + outer probe, X + Y axes (4 lines).
- Adds `ThreeDProbeStrategyTests` (6 tests): no `[XYZ]-[` pattern, both probe points captured, midpoint expression evaluates to `(X1-X2)/2` with substituted concrete values. The math test passes both before and after, guarding future refactors.

Reported by @dgz; root cause confirmed by FluidNC dev @MitchBradley. Verified on the latest beta.

## Test plan
- [x] `dotnet test tests/NcSender.Server.Tests/` — 230/230 pass
- [x] User-verified on FluidNC hardware (beta build)