### PR TITLE
Make FluidNC + grblHAL auto-reconnect bulletproof

### DIFF
--- a/.scripts/dev-windows.ps1
+++ b/.scripts/dev-windows.ps1
@@ -23,8 +23,11 @@ $ErrorActionPreference = 'Stop'
 $RepoRoot = (Resolve-Path "$PSScriptRoot\..").Path
 $ClientSrc = Join-Path $RepoRoot 'src\NcSender.Client'
 $ClientDistSrc = Join-Path $ClientSrc 'dist'
-$ClientDistStaged = Join-Path $RepoRoot 'client\dist'
 $ServerProj = Join-Path $RepoRoot 'src\NcSender.Server'
+# Stage next to the server binary so FindClientDist's BaseDirectory\client\dist
+# candidate resolves regardless of cwd. dotnet run uses the project dir as
+# cwd, so the repo-root staging path doesn't get hit during dev.
+$ClientDistStaged = Join-Path $ServerProj 'bin\Debug\net10.0\client\dist'
 
 function Write-Step([string]$Message) {
     Write-Host "==> $Message" -ForegroundColor Cyan

--- a/.scripts/dev-windows.ps1
+++ b/.scripts/dev-windows.ps1
@@ -1,0 +1,81 @@
+#requires -Version 5.1
+<#
+    Dev runner for Windows. Builds the Vite client, stages it where the
+    server expects (<repo>/client/dist), and runs the server on port 8090
+    serving both the API and the UI from the same origin.
+
+    Usage:
+        ./scripts/dev-windows.ps1                # full build + run
+        ./scripts/dev-windows.ps1 -SkipClient    # skip client rebuild (server only)
+        ./scripts/dev-windows.ps1 -SkipServer    # build client only (no run)
+#>
+
+[CmdletBinding()]
+param(
+    [switch]$SkipClient,
+    [switch]$SkipServer,
+    [switch]$Clean
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Resolve repo root (two levels up from this script).
+$RepoRoot = (Resolve-Path "$PSScriptRoot\..").Path
+$ClientSrc = Join-Path $RepoRoot 'src\NcSender.Client'
+$ClientDistSrc = Join-Path $ClientSrc 'dist'
+$ClientDistStaged = Join-Path $RepoRoot 'client\dist'
+$ServerProj = Join-Path $RepoRoot 'src\NcSender.Server'
+
+function Write-Step([string]$Message) {
+    Write-Host "==> $Message" -ForegroundColor Cyan
+}
+
+if ($Clean -and (Test-Path $ClientDistStaged)) {
+    Write-Step "Cleaning $ClientDistStaged"
+    Remove-Item -Recurse -Force $ClientDistStaged
+}
+
+if (-not $SkipClient) {
+    Push-Location $ClientSrc
+    try {
+        if (-not (Test-Path 'node_modules')) {
+            Write-Step 'Installing client dependencies (npm install)…'
+            npm install
+            if ($LASTEXITCODE -ne 0) { throw 'npm install failed' }
+        }
+
+        Write-Step 'Building client (npm run build)…'
+        npm run build
+        if ($LASTEXITCODE -ne 0) { throw 'npm run build failed' }
+    }
+    finally {
+        Pop-Location
+    }
+
+    if (-not (Test-Path $ClientDistSrc)) {
+        throw "Vite build output not found at $ClientDistSrc"
+    }
+
+    Write-Step "Staging client to $ClientDistStaged"
+    if (Test-Path $ClientDistStaged) { Remove-Item -Recurse -Force $ClientDistStaged }
+    New-Item -ItemType Directory -Force -Path $ClientDistStaged | Out-Null
+    Copy-Item -Recurse -Force "$ClientDistSrc\*" $ClientDistStaged
+}
+
+if ($SkipServer) {
+    Write-Step 'Skipping server (–SkipServer). Done.'
+    return
+}
+
+Write-Step 'Building server (dotnet build)…'
+dotnet build $ServerProj
+if ($LASTEXITCODE -ne 0) { throw 'dotnet build failed' }
+
+Write-Step 'Running server on http://localhost:8090 (Ctrl-C to stop)'
+Push-Location $RepoRoot
+try {
+    dotnet run --project $ServerProj --no-build
+}
+finally {
+    Pop-Location
+}

--- a/src/NcSender.Server/Connection/AutoConnectService.cs
+++ b/src/NcSender.Server/Connection/AutoConnectService.cs
@@ -131,13 +131,23 @@ public class AutoConnectService : BackgroundService
 
         await TryConnectToTarget(probeSettings, target, ct);
 
-        // If transport is open (connected or verifying), wait for greeting
-        if (_controller.IsTransportOpen && _controller.ActiveProtocol is null)
+        // Wait for the controller to be fully connected (greeting received +
+        // first status report parsed). Poll rather than fixed delay because
+        // FluidNC over WiFi can take 8-10s to finish booting and emit its
+        // canonical Grbl greeting, while grblHAL is sub-second. Bail early
+        // if the transport drops on its own (e.g. CncController hits its
+        // own greeting timeout).
+        if (_controller.IsTransportOpen && !_controller.IsConnected)
         {
-            // Wait for controller to send greeting (e-stop/alarm state may delay it)
-            await Task.Delay(3000, ct);
+            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(15);
+            while (DateTime.UtcNow < deadline)
+            {
+                await Task.Delay(200, ct);
+                if (_controller.IsConnected) break;
+                if (!_controller.IsTransportOpen) break;
+            }
 
-            if (_controller.ActiveProtocol is null && !_controller.IsConnected)
+            if (!_controller.IsConnected)
             {
                 _logger.LogInformation("No CNC greeting on {Port}, trying next port", port);
                 _controller.Disconnect();

--- a/src/NcSender.Server/Connection/CncController.cs
+++ b/src/NcSender.Server/Connection/CncController.cs
@@ -221,7 +221,10 @@ public partial class CncController : ICncController
                     _logger.LogInformation("Soft-reset sent, waiting for greeting...");
             });
 
-        // Start verification timeout — disconnect if no greeting received
+        // Start verification timeout — disconnect if no greeting received.
+        // 15s covers FluidNC's slow boot (config dump + WiFi STA connect +
+        // mDNS) which routinely exceeds 5s before the canonical Grbl
+        // greeting line is emitted. grblHAL is sub-second so this is safe.
         _verificationCts?.Cancel();
         _verificationCts = new CancellationTokenSource();
         var cts = _verificationCts;
@@ -229,10 +232,10 @@ public partial class CncController : ICncController
         {
             try
             {
-                await Task.Delay(5000, cts.Token);
+                await Task.Delay(15000, cts.Token);
                 if (_isVerifying && !_hasReceivedGreeting)
                 {
-                    _logger.LogWarning("No CNC greeting received within 5s, disconnecting (wrong device?)");
+                    _logger.LogWarning("No CNC greeting received within 15s, disconnecting (wrong device?)");
                     OnConnectionLost(new TimeoutException("No CNC greeting received"));
                 }
             }

--- a/src/NcSender.Server/Protocols/FluidNc/FluidNcProtocol.cs
+++ b/src/NcSender.Server/Protocols/FluidNc/FluidNcProtocol.cs
@@ -13,7 +13,18 @@ public class FluidNcProtocol : IProtocolHandler
     public string AlarmFetchCommand => "$A";
 
     public bool MatchesGreeting(string line)
-        => line.Contains("FluidNC", StringComparison.OrdinalIgnoreCase);
+    {
+        // Require the canonical Grbl ready greeting — emitted only after the
+        // controller finishes booting (config dump, WiFi, mDNS). A loose
+        // Contains("FluidNC") used to match the banner "[MSG:INFO: FluidNC ...]"
+        // that arrives ~5s before the controller is actually ready, causing
+        // AutoConnect to lock onto the port before status polling could
+        // succeed and then drop the connection.
+        var trimmed = line.TrimStart();
+        return trimmed.StartsWith("Grbl ", StringComparison.OrdinalIgnoreCase)
+            && trimmed.Contains("FluidNC", StringComparison.OrdinalIgnoreCase)
+            && trimmed.Contains("for help", StringComparison.OrdinalIgnoreCase);
+    }
 
     public string[] GetInitCommands()
         => ["$G", "$I", "$#"];

--- a/src/NcSender.Server/Protocols/GrblHal/GrblHalProtocol.cs
+++ b/src/NcSender.Server/Protocols/GrblHal/GrblHalProtocol.cs
@@ -17,8 +17,15 @@ public partial class GrblHalProtocol : IProtocolHandler
     public string? ErrorFetchCommand => "$EE";
 
     public bool MatchesGreeting(string line)
-        => line.StartsWith("grbl", StringComparison.OrdinalIgnoreCase)
-           && !line.Contains("FluidNC", StringComparison.OrdinalIgnoreCase);
+    {
+        // Canonical Grbl ready greeting: "Grbl X.Y... '$' for help" or
+        // "GrblHAL X.Y... '$' or '$HELP' for help". Excludes FluidNC, which
+        // also starts with "Grbl" in its greeting line.
+        var trimmed = line.TrimStart();
+        return trimmed.StartsWith("Grbl", StringComparison.OrdinalIgnoreCase)
+            && trimmed.Contains("for help", StringComparison.OrdinalIgnoreCase)
+            && !trimmed.Contains("FluidNC", StringComparison.OrdinalIgnoreCase);
+    }
 
     public string[] GetInitCommands()
         => ["$G", "$#=_tool_offset", "$I", "$pinstate", "$#"];

--- a/tests/NcSender.Server.Tests/ProtocolGreetingTests.cs
+++ b/tests/NcSender.Server.Tests/ProtocolGreetingTests.cs
@@ -1,0 +1,88 @@
+using NcSender.Server.Protocols.FluidNc;
+using NcSender.Server.Protocols.GrblHal;
+
+namespace NcSender.Server.Tests;
+
+// Greeting detection guards auto-connect: the moment a protocol declares
+// "this is mine", AutoConnectService treats the controller as identified.
+// Matching too loosely (e.g. on the FluidNC banner that arrives ~5s before
+// the controller is actually ready) trips the connection sequence and
+// leaves the user in an endless retry loop. These tests pin the canonical
+// "Grbl X.Y ... '$' for help" greeting line as the ONLY match for both
+// grblHAL and FluidNC, with all the boot-time noise rejected.
+public class ProtocolGreetingTests
+{
+    private readonly FluidNcProtocol _fluidnc = new();
+    private readonly GrblHalProtocol _grblhal = new();
+
+    // === FluidNC: the banner is NOT a greeting ===
+    // Captured from a real Windows + FluidNC v4.0.1 boot sequence.
+
+    [Theory]
+    [InlineData("[MSG:INFO: FluidNC v4.0.1 https://github.com/bdring/FluidNC]")]
+    [InlineData("[MSG:INFO: Local filesystem type is littlefs]")]
+    [InlineData("[MSG:INFO: Configuration file:config.yaml]")]
+    [InlineData("[MSG:INFO: Machine XYZ_CNC_Router]")]
+    [InlineData("[MSG:INFO: Board PiBotV49P]")]
+    [InlineData("[MSG:INFO: Axis count 4]")]
+    [InlineData("[MSG:INFO: Connecting to STA SSID:ChieWireless]")]
+    [InlineData("[MSG:INFO: Connecting.]")]
+    [InlineData("[MSG:INFO: Start mDNS with hostname:http://fluidnc.local/]")]
+    [InlineData("[MSG:INFO: HTTP started on port 80]")]
+    [InlineData("[MSG:INFO: Telnet started on port 23]")]
+    [InlineData("[MSG:INFO: Probe gpio.2:low:pu]")]
+    public void FluidNc_DoesNotMatchBootBanners(string line)
+    {
+        Assert.False(_fluidnc.MatchesGreeting(line),
+            $"FluidNC banner / boot message should not match greeting: {line}");
+    }
+
+    // === FluidNC: the canonical Grbl greeting line IS a greeting ===
+
+    [Theory]
+    [InlineData("Grbl 4.0 [FluidNC v4.0.1 (wifi) '$' for help]")]
+    [InlineData("Grbl 4.0 [FluidNC v4.0.1 (esp32s3-wifi) '$' for help]")]
+    [InlineData("Grbl 3.7 [FluidNC v3.7.18 (wifi) '$' for help]")]
+    public void FluidNc_MatchesCanonicalGreeting(string line)
+    {
+        Assert.True(_fluidnc.MatchesGreeting(line),
+            $"FluidNC canonical greeting should match: {line}");
+    }
+
+    // === grblHAL ===
+
+    [Theory]
+    [InlineData("GrblHAL 1.1f ['$' or '$HELP' for help]")]
+    [InlineData("Grbl 1.1h ['$' for help]")]
+    public void GrblHal_MatchesCanonicalGreeting(string line)
+    {
+        Assert.True(_grblhal.MatchesGreeting(line),
+            $"grblHAL greeting should match: {line}");
+    }
+
+    [Theory]
+    [InlineData("Grbl 4.0 [FluidNC v4.0.1 (wifi) '$' for help]")] // FluidNC announces itself with Grbl prefix; must not collide
+    [InlineData("[MSG:INFO: FluidNC v4.0.1 https://github.com/bdring/FluidNC]")]
+    [InlineData("ok")]
+    [InlineData("<Idle|MPos:0.000,0.000,0.000|FS:0,0>")]
+    public void GrblHal_DoesNotMatchOtherProtocolsOrNoise(string line)
+    {
+        Assert.False(_grblhal.MatchesGreeting(line),
+            $"grblHAL should not match: {line}");
+    }
+
+    // === Cross-firmware exclusivity: every line we recognise belongs to
+    //     exactly one protocol (or none — never both at once). ===
+
+    [Theory]
+    [InlineData("Grbl 4.0 [FluidNC v4.0.1 (wifi) '$' for help]")]
+    [InlineData("GrblHAL 1.1f ['$' or '$HELP' for help]")]
+    [InlineData("[MSG:INFO: FluidNC v4.0.1 https://github.com/bdring/FluidNC]")]
+    [InlineData("ok")]
+    public void Greeting_AtMostOneProtocolMatches(string line)
+    {
+        var hits = (_fluidnc.MatchesGreeting(line) ? 1 : 0)
+                 + (_grblhal.MatchesGreeting(line) ? 1 : 0);
+        Assert.True(hits <= 1, $"More than one protocol matched line: {line}");
+    }
+}


### PR DESCRIPTION
## Summary
Three coupled bugs caused auto-connect to lock onto FluidNC ports then drop the connection in an endless retry loop, especially on Windows.

1. **`FluidNcProtocol.MatchesGreeting()`** did `Contains("FluidNC")`, so it matched the boot banner `[MSG:INFO: FluidNC v4.0.1 ...]` emitted ~5s before the controller is actually ready. AutoConnect would lock in protocol identification, then time out before the real Grbl greeting arrived. **Fix:** require the canonical `Grbl X.Y... FluidNC ... for help` line — only emitted after FluidNC finishes booting (config dump + WiFi STA + mDNS).
2. **AutoConnect** waited a fixed 3s after opening the port — way too short for FluidNC over WiFi (8–10s boot is normal). **Fix:** poll `IsConnected` every 200ms up to 15s, short-circuit on success, fail fast if the transport drops on its own.
3. **`CncController` verification timeout** was 5s, also too short. Bumped to 15s — grblHAL is sub-second so this stays safe for it.

Adds `ProtocolGreetingTests` with fixtures from a real Windows + FluidNC v4.0.1 boot trace: banner messages, config dump, mDNS, WiFi connect — all rejected. Only the canonical Grbl greeting matches. Cross-firmware exclusivity test ensures no line ever matches both protocols at once.

Also adds `.scripts/dev-windows.ps1` for testing on Windows boxes (build client, stage to server bin dir, run server on 8090).

## Test plan
- [x] `dotnet test tests/NcSender.Server.Tests/` — 255/255 pass (macOS + Windows)
- [x] User-verified on macOS with both FluidNC and grblHAL — connect / disconnect / swap controller all work
- [x] Tested on Windows dev environment via `.scripts/dev-windows.ps1`