### PR TITLE
Add command response timeout for manual sources

### DIFF
--- a/src/NcSender.Server/Connection/CncController.cs
+++ b/src/NcSender.Server/Connection/CncController.cs
@@ -362,7 +362,16 @@ public partial class CncController : ICncController
                     // Per-command timeout (see CommandTimeoutPolicy). null = indefinite
                     // for user-action holds (M0/M1/M6) and program pauses; the rest get
                     // tight bounds so a missed "ok" doesn't lock the entire queue.
-                    var timeout = CommandTimeoutPolicy.GetTimeout(entry.RawCommand);
+                    //
+                    // Job-streamed lines (SourceId="job"/"resume") bypass the timeout —
+                    // the controller's planner buffer naturally paces acks during a
+                    // running program, and a slow motion can legitimately delay an
+                    // ack well past the 500ms default. Timeouts are for manual
+                    // commands (jogs, terminal input, panel actions) where a stuck
+                    // queue is what the user perceives as a frozen UI.
+                    var sourceId = entry.Meta?.SourceId;
+                    var isJobStream = sourceId is "job" or "resume";
+                    var timeout = isJobStream ? null : CommandTimeoutPolicy.GetTimeout(entry.RawCommand);
                     try
                     {
                         if (timeout is { } t)

--- a/src/NcSender.Server/Connection/CncController.cs
+++ b/src/NcSender.Server/Connection/CncController.cs
@@ -359,18 +359,16 @@ public partial class CncController : ICncController
 
                     LogCommandSent(entry.RawCommand, isRealTime: false);
 
-                    // Per-command timeout (see CommandTimeoutPolicy). null = indefinite
-                    // for user-action holds (M0/M1/M6) and program pauses; the rest get
-                    // tight bounds so a missed "ok" doesn't lock the entire queue.
-                    //
-                    // Multi-line streamed sequences (job/resume/macro) bypass the
-                    // timeout — the planner buffer naturally paces acks and a slow
-                    // motion can legitimately delay "ok" past the 500ms default.
-                    // Timeouts are for one-off manual commands (jogs, terminal,
-                    // panel actions) where a stuck queue is the perceived freeze.
+                    // Per-command timeout (see CommandTimeoutPolicy) only applies to
+                    // direct user-driven sources where a stuck queue feels like a
+                    // frozen UI: terminal/panel input (client), jog buttons,
+                    // pendant. Everything else (job/macro streaming, internal
+                    // system/event/probe/controller-files calls) waits as long as
+                    // the controller takes — the planner buffer paces things
+                    // naturally and a slow motion can legitimately delay "ok".
                     var sourceId = entry.Meta?.SourceId;
-                    var isStreamed = sourceId is "job" or "resume" or "macro";
-                    var timeout = isStreamed ? null : CommandTimeoutPolicy.GetTimeout(entry.RawCommand);
+                    var isManual = sourceId is "client" or "jog" or "usb-pendant";
+                    var timeout = isManual ? CommandTimeoutPolicy.GetTimeout(entry.RawCommand) : null;
                     try
                     {
                         if (timeout is { } t)

--- a/src/NcSender.Server/Connection/CncController.cs
+++ b/src/NcSender.Server/Connection/CncController.cs
@@ -359,11 +359,28 @@ public partial class CncController : ICncController
 
                     LogCommandSent(entry.RawCommand, isRealTime: false);
 
-                    // Wait for the TCS to be completed by HandleCommandOk/HandleCommandError.
-                    // No timeout — commands like M0 (program pause) hold until the user
-                    // sends ~ (cycle start), which is a real-time command that bypasses
-                    // the queue. Disconnection cancels via ct.
-                    await entry.Tcs.Task.WaitAsync(ct);
+                    // Per-command timeout (see CommandTimeoutPolicy). null = indefinite
+                    // for user-action holds (M0/M1/M6) and program pauses; the rest get
+                    // tight bounds so a missed "ok" doesn't lock the entire queue.
+                    var timeout = CommandTimeoutPolicy.GetTimeout(entry.RawCommand);
+                    try
+                    {
+                        if (timeout is { } t)
+                            await entry.Tcs.Task.WaitAsync(t, ct);
+                        else
+                            await entry.Tcs.Task.WaitAsync(ct);
+                    }
+                    catch (TimeoutException)
+                    {
+                        var msg = $"No 'ok' from controller within {timeout!.Value.TotalSeconds:0.##}s for: {entry.RawCommand}";
+                        _logger.LogWarning(msg);
+                        var err = new TimeoutException(msg);
+                        entry.Tcs.TrySetException(err);
+                        EmitCommandAck(entry, "error", msg);
+                        // Continue draining the queue — don't soft-reset. If the
+                        // controller is genuinely hung, subsequent commands will
+                        // also time out and the user can hit Stop manually.
+                    }
                 }
                 catch (OperationCanceledException) when (ct.IsCancellationRequested)
                 {

--- a/src/NcSender.Server/Connection/CncController.cs
+++ b/src/NcSender.Server/Connection/CncController.cs
@@ -363,15 +363,14 @@ public partial class CncController : ICncController
                     // for user-action holds (M0/M1/M6) and program pauses; the rest get
                     // tight bounds so a missed "ok" doesn't lock the entire queue.
                     //
-                    // Job-streamed lines (SourceId="job"/"resume") bypass the timeout —
-                    // the controller's planner buffer naturally paces acks during a
-                    // running program, and a slow motion can legitimately delay an
-                    // ack well past the 500ms default. Timeouts are for manual
-                    // commands (jogs, terminal input, panel actions) where a stuck
-                    // queue is what the user perceives as a frozen UI.
+                    // Multi-line streamed sequences (job/resume/macro) bypass the
+                    // timeout — the planner buffer naturally paces acks and a slow
+                    // motion can legitimately delay "ok" past the 500ms default.
+                    // Timeouts are for one-off manual commands (jogs, terminal,
+                    // panel actions) where a stuck queue is the perceived freeze.
                     var sourceId = entry.Meta?.SourceId;
-                    var isJobStream = sourceId is "job" or "resume";
-                    var timeout = isJobStream ? null : CommandTimeoutPolicy.GetTimeout(entry.RawCommand);
+                    var isStreamed = sourceId is "job" or "resume" or "macro";
+                    var timeout = isStreamed ? null : CommandTimeoutPolicy.GetTimeout(entry.RawCommand);
                     try
                     {
                         if (timeout is { } t)

--- a/src/NcSender.Server/Connection/CommandTimeoutPolicy.cs
+++ b/src/NcSender.Server/Connection/CommandTimeoutPolicy.cs
@@ -13,7 +13,7 @@ public static partial class CommandTimeoutPolicy
     private static readonly TimeSpan LongMechanical = TimeSpan.FromMinutes(5);
     private static readonly TimeSpan Probing = TimeSpan.FromSeconds(60);
     private static readonly TimeSpan Motion = TimeSpan.FromSeconds(10);
-    private static readonly TimeSpan Default = TimeSpan.FromSeconds(1);
+    private static readonly TimeSpan Default = TimeSpan.FromMilliseconds(500);
 
     public static TimeSpan? GetTimeout(string command)
     {

--- a/src/NcSender.Server/Connection/CommandTimeoutPolicy.cs
+++ b/src/NcSender.Server/Connection/CommandTimeoutPolicy.cs
@@ -14,7 +14,7 @@ public static partial class CommandTimeoutPolicy
     private static readonly TimeSpan Probing = TimeSpan.FromSeconds(60);
     private static readonly TimeSpan Motion = TimeSpan.FromSeconds(10);
     private static readonly TimeSpan Spindle = TimeSpan.FromSeconds(60);
-    private static readonly TimeSpan Default = TimeSpan.FromMilliseconds(500);
+    private static readonly TimeSpan Default = TimeSpan.FromSeconds(1);
 
     public static TimeSpan? GetTimeout(string command)
     {

--- a/src/NcSender.Server/Connection/CommandTimeoutPolicy.cs
+++ b/src/NcSender.Server/Connection/CommandTimeoutPolicy.cs
@@ -1,76 +1,15 @@
-using System.Globalization;
-using System.Text.RegularExpressions;
-
 namespace NcSender.Server.Connection;
 
 /// <summary>
-/// Per-command response timeout policy. Prevents the queue from stalling when
-/// the controller drops or delays an "ok" ack. A null timeout means wait
-/// indefinitely (e.g. M0 program-stop, which holds until the user sends ~).
+/// Response timeout for manual commands (terminal/panel/jog/pendant). The
+/// only thing this guards against is the queue stalling when the controller
+/// silently drops or delays an "ok" — i.e. choking. Long-running ops like
+/// homing, motion, spindle ramp, dwell are the controller's responsibility;
+/// jobs and macros bypass the timeout entirely (see CncController).
 /// </summary>
-public static partial class CommandTimeoutPolicy
+public static class CommandTimeoutPolicy
 {
-    private static readonly TimeSpan LongMechanical = TimeSpan.FromMinutes(5);
-    private static readonly TimeSpan Probing = TimeSpan.FromSeconds(60);
-    private static readonly TimeSpan Motion = TimeSpan.FromSeconds(10);
-    private static readonly TimeSpan Spindle = TimeSpan.FromSeconds(60);
-    private static readonly TimeSpan Default = TimeSpan.FromSeconds(1);
+    public static readonly TimeSpan Default = TimeSpan.FromSeconds(1);
 
-    public static TimeSpan? GetTimeout(string command)
-    {
-        var trimmed = (command ?? "").Trim();
-
-        // Indefinite: M0 / M1 (program stop) hold until cycle-start `~`;
-        // M6 (tool change) may prompt the user via a plugin dialog.
-        if (IndefiniteHoldRegex().IsMatch(trimmed))
-            return null;
-
-        // Long mechanical: homing on big machines, traverse to predefined.
-        if (LongMechanicalRegex().IsMatch(trimmed))
-            return LongMechanical;
-
-        // Probing: travels over the configured search distance at slow feed.
-        if (ProbingRegex().IsMatch(trimmed))
-            return Probing;
-
-        // Dwell: G4 P<seconds>. Self-describing — parse and add a buffer.
-        var dwell = DwellRegex().Match(trimmed);
-        if (dwell.Success && double.TryParse(dwell.Groups[1].Value,
-                NumberStyles.Float, CultureInfo.InvariantCulture, out var dwellSec))
-        {
-            return TimeSpan.FromSeconds(dwellSec + 2);
-        }
-
-        // Spindle on/off: controllers with a configured spin-up/down ramp
-        // (grblHAL $340/$341) hold the ack until the spindle reaches speed.
-        if (SpindleRegex().IsMatch(trimmed))
-            return Spindle;
-
-        // Motion: planner buffer can delay the ack on long slow feeds.
-        if (MotionRegex().IsMatch(trimmed))
-            return Motion;
-
-        // Everything else (jogs, queries, modes, spindle, coolant, etc.)
-        // acks in tens of milliseconds; a tight timeout makes a stuck
-        // queue recover quickly.
-        return Default;
-    }
-
-    [GeneratedRegex(@"\bM0*[01]\b|\bM0*6\b", RegexOptions.IgnoreCase)]
-    private static partial Regex IndefiniteHoldRegex();
-
-    [GeneratedRegex(@"^\s*\$H[A-Z]?\b|\bG0*2[89]\b|\bG0*30\b", RegexOptions.IgnoreCase)]
-    private static partial Regex LongMechanicalRegex();
-
-    [GeneratedRegex(@"\bG0*38\.[2-5]\b", RegexOptions.IgnoreCase)]
-    private static partial Regex ProbingRegex();
-
-    [GeneratedRegex(@"\bG0*4\b[^P]*P(\d+(?:\.\d+)?)", RegexOptions.IgnoreCase)]
-    private static partial Regex DwellRegex();
-
-    [GeneratedRegex(@"\bG0*[0-3]\b", RegexOptions.IgnoreCase)]
-    private static partial Regex MotionRegex();
-
-    [GeneratedRegex(@"\bM0*[345]\b", RegexOptions.IgnoreCase)]
-    private static partial Regex SpindleRegex();
+    public static TimeSpan? GetTimeout(string command) => Default;
 }

--- a/src/NcSender.Server/Connection/CommandTimeoutPolicy.cs
+++ b/src/NcSender.Server/Connection/CommandTimeoutPolicy.cs
@@ -1,0 +1,67 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace NcSender.Server.Connection;
+
+/// <summary>
+/// Per-command response timeout policy. Prevents the queue from stalling when
+/// the controller drops or delays an "ok" ack. A null timeout means wait
+/// indefinitely (e.g. M0 program-stop, which holds until the user sends ~).
+/// </summary>
+public static partial class CommandTimeoutPolicy
+{
+    private static readonly TimeSpan LongMechanical = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan Probing = TimeSpan.FromSeconds(60);
+    private static readonly TimeSpan Motion = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan Default = TimeSpan.FromSeconds(1);
+
+    public static TimeSpan? GetTimeout(string command)
+    {
+        var trimmed = (command ?? "").Trim();
+
+        // Indefinite: M0 / M1 (program stop) hold until cycle-start `~`;
+        // M6 (tool change) may prompt the user via a plugin dialog.
+        if (IndefiniteHoldRegex().IsMatch(trimmed))
+            return null;
+
+        // Long mechanical: homing on big machines, traverse to predefined.
+        if (LongMechanicalRegex().IsMatch(trimmed))
+            return LongMechanical;
+
+        // Probing: travels over the configured search distance at slow feed.
+        if (ProbingRegex().IsMatch(trimmed))
+            return Probing;
+
+        // Dwell: G4 P<seconds>. Self-describing — parse and add a buffer.
+        var dwell = DwellRegex().Match(trimmed);
+        if (dwell.Success && double.TryParse(dwell.Groups[1].Value,
+                NumberStyles.Float, CultureInfo.InvariantCulture, out var dwellSec))
+        {
+            return TimeSpan.FromSeconds(dwellSec + 2);
+        }
+
+        // Motion: planner buffer can delay the ack on long slow feeds.
+        if (MotionRegex().IsMatch(trimmed))
+            return Motion;
+
+        // Everything else (jogs, queries, modes, spindle, coolant, etc.)
+        // acks in tens of milliseconds; a tight timeout makes a stuck
+        // queue recover quickly.
+        return Default;
+    }
+
+    [GeneratedRegex(@"\bM0*[01]\b|\bM0*6\b", RegexOptions.IgnoreCase)]
+    private static partial Regex IndefiniteHoldRegex();
+
+    [GeneratedRegex(@"^\s*\$H[A-Z]?\b|\bG0*2[89]\b|\bG0*30\b", RegexOptions.IgnoreCase)]
+    private static partial Regex LongMechanicalRegex();
+
+    [GeneratedRegex(@"\bG0*38\.[2-5]\b", RegexOptions.IgnoreCase)]
+    private static partial Regex ProbingRegex();
+
+    [GeneratedRegex(@"\bG0*4\b[^P]*P(\d+(?:\.\d+)?)", RegexOptions.IgnoreCase)]
+    private static partial Regex DwellRegex();
+
+    [GeneratedRegex(@"\bG0*[0-3]\b", RegexOptions.IgnoreCase)]
+    private static partial Regex MotionRegex();
+}

--- a/src/NcSender.Server/Connection/CommandTimeoutPolicy.cs
+++ b/src/NcSender.Server/Connection/CommandTimeoutPolicy.cs
@@ -13,6 +13,7 @@ public static partial class CommandTimeoutPolicy
     private static readonly TimeSpan LongMechanical = TimeSpan.FromMinutes(5);
     private static readonly TimeSpan Probing = TimeSpan.FromSeconds(60);
     private static readonly TimeSpan Motion = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan Spindle = TimeSpan.FromSeconds(60);
     private static readonly TimeSpan Default = TimeSpan.FromMilliseconds(500);
 
     public static TimeSpan? GetTimeout(string command)
@@ -40,6 +41,11 @@ public static partial class CommandTimeoutPolicy
             return TimeSpan.FromSeconds(dwellSec + 2);
         }
 
+        // Spindle on/off: controllers with a configured spin-up/down ramp
+        // (grblHAL $340/$341) hold the ack until the spindle reaches speed.
+        if (SpindleRegex().IsMatch(trimmed))
+            return Spindle;
+
         // Motion: planner buffer can delay the ack on long slow feeds.
         if (MotionRegex().IsMatch(trimmed))
             return Motion;
@@ -64,4 +70,7 @@ public static partial class CommandTimeoutPolicy
 
     [GeneratedRegex(@"\bG0*[0-3]\b", RegexOptions.IgnoreCase)]
     private static partial Regex MotionRegex();
+
+    [GeneratedRegex(@"\bM0*[345]\b", RegexOptions.IgnoreCase)]
+    private static partial Regex SpindleRegex();
 }

--- a/tests/NcSender.Server.Tests/CommandTimeoutPolicyTests.cs
+++ b/tests/NcSender.Server.Tests/CommandTimeoutPolicyTests.cs
@@ -2,141 +2,30 @@ using NcSender.Server.Connection;
 
 namespace NcSender.Server.Tests;
 
-// Per-command response timeouts prevent the queue from getting stuck when the
-// controller drops or delays an "ok" ack. Without this, a single missed ack
-// leaves every subsequent command spinning forever, and the only escape is a
-// soft-reset via the Stop button. The policy buckets each command so genuinely
-// long ops (homing, M0 holds, dwell) keep their generous wait, while the
-// hot-path commands (jogs, queries, modes) fail fast.
 public class CommandTimeoutPolicyTests
 {
-    [Theory]
-    [InlineData("M0")]
-    [InlineData("M00")]
-    [InlineData("M1")]
-    [InlineData("M01")]
-    [InlineData("M001")]
-    [InlineData("M6")]
-    [InlineData("M06")]
-    [InlineData("M6 T3")]
-    [InlineData("m0")]
-    [InlineData("  M0  ")]
-    public void Indefinite_HoldsUntilUserAction(string command)
-    {
-        Assert.Null(CommandTimeoutPolicy.GetTimeout(command));
-    }
-
-    [Theory]
-    [InlineData("$H")]
-    [InlineData("$HX")]
-    [InlineData("$HY")]
-    [InlineData("$HZ")]
-    [InlineData("G28")]
-    [InlineData("G30")]
-    [InlineData("G28 X0 Y0")]
-    [InlineData("G028")]
-    public void LongMechanical_GetsFiveMinutes(string command)
-    {
-        var timeout = CommandTimeoutPolicy.GetTimeout(command);
-        Assert.Equal(TimeSpan.FromMinutes(5), timeout);
-    }
-
-    [Theory]
-    [InlineData("G38.2 Z-50 F100")]
-    [InlineData("G38.3 X-25 F500")]
-    [InlineData("G38.4 Z5 F50")]
-    [InlineData("G38.5 X1 F50")]
-    public void Probing_GetsSixtySeconds(string command)
-    {
-        var timeout = CommandTimeoutPolicy.GetTimeout(command);
-        Assert.Equal(TimeSpan.FromSeconds(60), timeout);
-    }
-
-    [Theory]
-    [InlineData("G4 P0.5", 0.5)]
-    [InlineData("G4 P1", 1.0)]
-    [InlineData("G4 P10", 10.0)]
-    [InlineData("G04 P2.5", 2.5)]
-    [InlineData("g4 p0.2", 0.2)]
-    public void Dwell_ParsesPValuePlusBuffer(string command, double expectedSeconds)
-    {
-        var timeout = CommandTimeoutPolicy.GetTimeout(command);
-        Assert.NotNull(timeout);
-        Assert.Equal(expectedSeconds + 2, timeout.Value.TotalSeconds, precision: 3);
-    }
-
-    [Theory]
-    [InlineData("G0 X10")]
-    [InlineData("G1 X10 Y20 F500")]
-    [InlineData("G2 X1 Y1 I0.5 J0")]
-    [InlineData("G3 X0 Y0 I-1 J0")]
-    [InlineData("G00 X100")]
-    [InlineData("G01 X10 F100")]
-    public void Motion_GetsTenSeconds(string command)
-    {
-        var timeout = CommandTimeoutPolicy.GetTimeout(command);
-        Assert.Equal(TimeSpan.FromSeconds(10), timeout);
-    }
+    // The policy is intentionally minimal: a flat 1s on manual commands so a
+    // genuine controller choke surfaces fast. Long-running ops (homing,
+    // motion, spindle ramp, dwell) are paced by the controller itself; jobs
+    // and macros bypass the timeout via the source-id whitelist in
+    // CncController.
 
     [Theory]
     [InlineData("$J=G91 X10 F1000")]
-    [InlineData("$J=G91 Y-1 F500")]
-    [InlineData("$J=G53 G90 X100 Y100 F2000")]
-    public void Jog_GetsOneSecond(string command)
-    {
-        var timeout = CommandTimeoutPolicy.GetTimeout(command);
-        Assert.Equal(TimeSpan.FromSeconds(1), timeout);
-    }
-
-    [Theory]
     [InlineData("M3 S1000")]
-    [InlineData("M3 S1200")]
-    [InlineData("M03 S5000")]
-    [InlineData("M4 S500")]
-    [InlineData("M04")]
     [InlineData("M5")]
-    [InlineData("M05")]
-    [InlineData("m3 s10000")]
-    public void Spindle_GetsSixtySeconds(string command)
-    {
-        var timeout = CommandTimeoutPolicy.GetTimeout(command);
-        Assert.Equal(TimeSpan.FromSeconds(60), timeout);
-    }
-
-    [Theory]
+    [InlineData("$H")]
+    [InlineData("G0 X10")]
+    [InlineData("G1 X10 F500")]
+    [InlineData("G4 P0.5")]
+    [InlineData("G38.2 Z-10 F100")]
+    [InlineData("M0")]
+    [InlineData("M6 T3")]
     [InlineData("$$")]
-    [InlineData("$G")]
-    [InlineData("$#")]
-    [InlineData("$I")]
     [InlineData("$X")]
-    [InlineData("$A")]
-    [InlineData("$EA")]
-    [InlineData("$EE")]
-    [InlineData("$pinstate")]
-    [InlineData("M7")]
-    [InlineData("M8")]
-    [InlineData("M9")]
-    [InlineData("M61 Q3")]
-    [InlineData("G20")]
-    [InlineData("G21")]
-    [InlineData("G90")]
-    [InlineData("G91")]
-    [InlineData("G93")]
-    [InlineData("G94")]
-    [InlineData("G54")]
-    [InlineData("G59")]
-    [InlineData("G10 L20 X0")]
-    [InlineData("G92 X0 Y0")]
-    [InlineData("$RST=*")]
-    public void Default_GetsOneSecond(string command)
+    [InlineData("")]
+    public void EveryCommand_GetsOneSecond(string command)
     {
-        var timeout = CommandTimeoutPolicy.GetTimeout(command);
-        Assert.Equal(TimeSpan.FromSeconds(1), timeout);
-    }
-
-    [Fact]
-    public void EmptyCommand_GetsDefaultTimeout()
-    {
-        Assert.Equal(TimeSpan.FromSeconds(1), CommandTimeoutPolicy.GetTimeout(""));
+        Assert.Equal(TimeSpan.FromSeconds(1), CommandTimeoutPolicy.GetTimeout(command));
     }
 }

--- a/tests/NcSender.Server.Tests/CommandTimeoutPolicyTests.cs
+++ b/tests/NcSender.Server.Tests/CommandTimeoutPolicyTests.cs
@@ -1,0 +1,130 @@
+using NcSender.Server.Connection;
+
+namespace NcSender.Server.Tests;
+
+// Per-command response timeouts prevent the queue from getting stuck when the
+// controller drops or delays an "ok" ack. Without this, a single missed ack
+// leaves every subsequent command spinning forever, and the only escape is a
+// soft-reset via the Stop button. The policy buckets each command so genuinely
+// long ops (homing, M0 holds, dwell) keep their generous wait, while the
+// hot-path commands (jogs, queries, modes) fail fast.
+public class CommandTimeoutPolicyTests
+{
+    [Theory]
+    [InlineData("M0")]
+    [InlineData("M00")]
+    [InlineData("M1")]
+    [InlineData("M01")]
+    [InlineData("M001")]
+    [InlineData("M6")]
+    [InlineData("M06")]
+    [InlineData("M6 T3")]
+    [InlineData("m0")]
+    [InlineData("  M0  ")]
+    public void Indefinite_HoldsUntilUserAction(string command)
+    {
+        Assert.Null(CommandTimeoutPolicy.GetTimeout(command));
+    }
+
+    [Theory]
+    [InlineData("$H")]
+    [InlineData("$HX")]
+    [InlineData("$HY")]
+    [InlineData("$HZ")]
+    [InlineData("G28")]
+    [InlineData("G30")]
+    [InlineData("G28 X0 Y0")]
+    [InlineData("G028")]
+    public void LongMechanical_GetsFiveMinutes(string command)
+    {
+        var timeout = CommandTimeoutPolicy.GetTimeout(command);
+        Assert.Equal(TimeSpan.FromMinutes(5), timeout);
+    }
+
+    [Theory]
+    [InlineData("G38.2 Z-50 F100")]
+    [InlineData("G38.3 X-25 F500")]
+    [InlineData("G38.4 Z5 F50")]
+    [InlineData("G38.5 X1 F50")]
+    public void Probing_GetsSixtySeconds(string command)
+    {
+        var timeout = CommandTimeoutPolicy.GetTimeout(command);
+        Assert.Equal(TimeSpan.FromSeconds(60), timeout);
+    }
+
+    [Theory]
+    [InlineData("G4 P0.5", 0.5)]
+    [InlineData("G4 P1", 1.0)]
+    [InlineData("G4 P10", 10.0)]
+    [InlineData("G04 P2.5", 2.5)]
+    [InlineData("g4 p0.2", 0.2)]
+    public void Dwell_ParsesPValuePlusBuffer(string command, double expectedSeconds)
+    {
+        var timeout = CommandTimeoutPolicy.GetTimeout(command);
+        Assert.NotNull(timeout);
+        Assert.Equal(expectedSeconds + 2, timeout.Value.TotalSeconds, precision: 3);
+    }
+
+    [Theory]
+    [InlineData("G0 X10")]
+    [InlineData("G1 X10 Y20 F500")]
+    [InlineData("G2 X1 Y1 I0.5 J0")]
+    [InlineData("G3 X0 Y0 I-1 J0")]
+    [InlineData("G00 X100")]
+    [InlineData("G01 X10 F100")]
+    public void Motion_GetsTenSeconds(string command)
+    {
+        var timeout = CommandTimeoutPolicy.GetTimeout(command);
+        Assert.Equal(TimeSpan.FromSeconds(10), timeout);
+    }
+
+    [Theory]
+    [InlineData("$J=G91 X10 F1000")]
+    [InlineData("$J=G91 Y-1 F500")]
+    [InlineData("$J=G53 G90 X100 Y100 F2000")]
+    public void Jog_GetsOneSecond(string command)
+    {
+        var timeout = CommandTimeoutPolicy.GetTimeout(command);
+        Assert.Equal(TimeSpan.FromSeconds(1), timeout);
+    }
+
+    [Theory]
+    [InlineData("$$")]
+    [InlineData("$G")]
+    [InlineData("$#")]
+    [InlineData("$I")]
+    [InlineData("$X")]
+    [InlineData("$A")]
+    [InlineData("$EA")]
+    [InlineData("$EE")]
+    [InlineData("$pinstate")]
+    [InlineData("M3 S1000")]
+    [InlineData("M4 S500")]
+    [InlineData("M5")]
+    [InlineData("M7")]
+    [InlineData("M8")]
+    [InlineData("M9")]
+    [InlineData("M61 Q3")]
+    [InlineData("G20")]
+    [InlineData("G21")]
+    [InlineData("G90")]
+    [InlineData("G91")]
+    [InlineData("G93")]
+    [InlineData("G94")]
+    [InlineData("G54")]
+    [InlineData("G59")]
+    [InlineData("G10 L20 X0")]
+    [InlineData("G92 X0 Y0")]
+    [InlineData("$RST=*")]
+    public void Default_GetsOneSecond(string command)
+    {
+        var timeout = CommandTimeoutPolicy.GetTimeout(command);
+        Assert.Equal(TimeSpan.FromSeconds(1), timeout);
+    }
+
+    [Fact]
+    public void EmptyCommand_GetsDefaultTimeout()
+    {
+        Assert.Equal(TimeSpan.FromSeconds(1), CommandTimeoutPolicy.GetTimeout(""));
+    }
+}

--- a/tests/NcSender.Server.Tests/CommandTimeoutPolicyTests.cs
+++ b/tests/NcSender.Server.Tests/CommandTimeoutPolicyTests.cs
@@ -89,6 +89,21 @@ public class CommandTimeoutPolicyTests
     }
 
     [Theory]
+    [InlineData("M3 S1000")]
+    [InlineData("M3 S1200")]
+    [InlineData("M03 S5000")]
+    [InlineData("M4 S500")]
+    [InlineData("M04")]
+    [InlineData("M5")]
+    [InlineData("M05")]
+    [InlineData("m3 s10000")]
+    public void Spindle_GetsSixtySeconds(string command)
+    {
+        var timeout = CommandTimeoutPolicy.GetTimeout(command);
+        Assert.Equal(TimeSpan.FromSeconds(60), timeout);
+    }
+
+    [Theory]
     [InlineData("$$")]
     [InlineData("$G")]
     [InlineData("$#")]
@@ -98,9 +113,6 @@ public class CommandTimeoutPolicyTests
     [InlineData("$EA")]
     [InlineData("$EE")]
     [InlineData("$pinstate")]
-    [InlineData("M3 S1000")]
-    [InlineData("M4 S500")]
-    [InlineData("M5")]
     [InlineData("M7")]
     [InlineData("M8")]
     [InlineData("M9")]

--- a/tests/NcSender.Server.Tests/CommandTimeoutPolicyTests.cs
+++ b/tests/NcSender.Server.Tests/CommandTimeoutPolicyTests.cs
@@ -82,10 +82,10 @@ public class CommandTimeoutPolicyTests
     [InlineData("$J=G91 X10 F1000")]
     [InlineData("$J=G91 Y-1 F500")]
     [InlineData("$J=G53 G90 X100 Y100 F2000")]
-    public void Jog_GetsHalfSecond(string command)
+    public void Jog_GetsOneSecond(string command)
     {
         var timeout = CommandTimeoutPolicy.GetTimeout(command);
-        Assert.Equal(TimeSpan.FromMilliseconds(500), timeout);
+        Assert.Equal(TimeSpan.FromSeconds(1), timeout);
     }
 
     [Theory]
@@ -128,15 +128,15 @@ public class CommandTimeoutPolicyTests
     [InlineData("G10 L20 X0")]
     [InlineData("G92 X0 Y0")]
     [InlineData("$RST=*")]
-    public void Default_GetsHalfSecond(string command)
+    public void Default_GetsOneSecond(string command)
     {
         var timeout = CommandTimeoutPolicy.GetTimeout(command);
-        Assert.Equal(TimeSpan.FromMilliseconds(500), timeout);
+        Assert.Equal(TimeSpan.FromSeconds(1), timeout);
     }
 
     [Fact]
     public void EmptyCommand_GetsDefaultTimeout()
     {
-        Assert.Equal(TimeSpan.FromMilliseconds(500), CommandTimeoutPolicy.GetTimeout(""));
+        Assert.Equal(TimeSpan.FromSeconds(1), CommandTimeoutPolicy.GetTimeout(""));
     }
 }

--- a/tests/NcSender.Server.Tests/CommandTimeoutPolicyTests.cs
+++ b/tests/NcSender.Server.Tests/CommandTimeoutPolicyTests.cs
@@ -82,10 +82,10 @@ public class CommandTimeoutPolicyTests
     [InlineData("$J=G91 X10 F1000")]
     [InlineData("$J=G91 Y-1 F500")]
     [InlineData("$J=G53 G90 X100 Y100 F2000")]
-    public void Jog_GetsOneSecond(string command)
+    public void Jog_GetsHalfSecond(string command)
     {
         var timeout = CommandTimeoutPolicy.GetTimeout(command);
-        Assert.Equal(TimeSpan.FromSeconds(1), timeout);
+        Assert.Equal(TimeSpan.FromMilliseconds(500), timeout);
     }
 
     [Theory]
@@ -116,15 +116,15 @@ public class CommandTimeoutPolicyTests
     [InlineData("G10 L20 X0")]
     [InlineData("G92 X0 Y0")]
     [InlineData("$RST=*")]
-    public void Default_GetsOneSecond(string command)
+    public void Default_GetsHalfSecond(string command)
     {
         var timeout = CommandTimeoutPolicy.GetTimeout(command);
-        Assert.Equal(TimeSpan.FromSeconds(1), timeout);
+        Assert.Equal(TimeSpan.FromMilliseconds(500), timeout);
     }
 
     [Fact]
     public void EmptyCommand_GetsDefaultTimeout()
     {
-        Assert.Equal(TimeSpan.FromSeconds(1), CommandTimeoutPolicy.GetTimeout(""));
+        Assert.Equal(TimeSpan.FromMilliseconds(500), CommandTimeoutPolicy.GetTimeout(""));
     }
 }


### PR DESCRIPTION
## Summary
Without a timeout on ok-acks, a single dropped or delayed `ok` from the controller leaves every subsequent command spinning forever — the only escape was the Stop button (which soft-resets and flushes everything). Worst on the pendant where queued jogs felt like the device was broken.

- Adds `CommandTimeoutPolicy` (flat 1s) and applies it in `CncController.ConsumeQueueAsync`.
- **Whitelist for enforcement:** only `client`, `jog`, `usb-pendant` source IDs.
- **Streamed sources bypass entirely:** `job`, `resume`, `macro`, `system`, `event`, `probe`, `controller-files`, etc. — the controller's planner buffer paces those naturally.
- On timeout: log warning, fail the active command (clearing the spinner in the UI), and continue draining the queue. No auto soft-reset — if the controller is genuinely hung, the next command also fails fast and the user can hit Stop manually.

## Test plan
- [x] `dotnet test tests/NcSender.Server.Tests/` — 268/268 pass
- [x] Verified jog/terminal recover within 1s on choke instead of needing Stop
- [x] Verified jobs run to completion without false timeouts on slow motions