### PR TITLE
Create setting to allow passthrough of M6 without special handling

### DIFF
--- a/src/NcSender.Server/CommandProcessor/CommandProcessor.cs
+++ b/src/NcSender.Server/CommandProcessor/CommandProcessor.cs
@@ -33,6 +33,7 @@ public class CommandProcessor : ICommandProcessor
     public async Task<CommandProcessorResult> ProcessAsync(string command, CommandProcessorContext processorContext)
     {
         var machineState = processorContext.MachineState;
+        var m6Passthrough = _settingsManager.GetSetting<bool>("tool.m6passthrough", false);
 
         // 1. Door state safety checks
         var doorResult = CheckDoorStateSafety(command, processorContext);
@@ -69,7 +70,7 @@ public class CommandProcessor : ICommandProcessor
         // 8. Determine return position for M6 tool change
         XyPosition? m6ReturnPosition = null;
         var m6UseWorkCoordinates = false;
-        if (isValidM6 && !sameToolCheck.IsSameTool)
+        if (isValidM6 && !sameToolCheck.IsSameTool && !m6Passthrough)
         {
             var nextXY = processorContext.NextXYPosition;
             if (nextXY is not null)
@@ -109,14 +110,14 @@ public class CommandProcessor : ICommandProcessor
         }
 
         // 12. Set isToolChanging flag for valid M6 (non-same-tool)
-        if (isValidM6 && !sameToolCheck.IsSameTool && !_context.State.MachineState.IsToolChanging)
+        if (isValidM6 && !sameToolCheck.IsSameTool && !_context.State.MachineState.IsToolChanging && !m6Passthrough)
         {
             _context.State.MachineState.IsToolChanging = true;
             _ = _broadcaster.Broadcast("server-state-updated", _context.State, NcSenderJsonContext.Default.ServerState);
         }
 
         // 13. Same-tool M6 skip
-        if (sameToolCheck.IsSameTool)
+        if (sameToolCheck.IsSameTool && !m6Passthrough)
         {
             var skipMessage = $"M6 T{sameToolCheck.ToolNumber}; Skipped, target tool is the same as the current tool.";
             _logger.LogInformation("Same-tool M6 detected: T{Tool} (current: T{Current}) - skipping",
@@ -159,7 +160,7 @@ public class CommandProcessor : ICommandProcessor
         };
 
         // 15. If valid M6 (non-same-tool), append return-to-position + sentinel
-        if (isValidM6)
+        if (isValidM6 && !m6Passthrough)
         {
             // Return-to-position only for manual invocation (not during program run)
             if (m6ReturnPosition is not null && !m6UseWorkCoordinates)

--- a/src/NcSender.Server/Configuration/SettingsManager.cs
+++ b/src/NcSender.Server/Configuration/SettingsManager.cs
@@ -246,7 +246,8 @@ public class SettingsManager : ISettingsManager
                 "count": 0,
                 "source": null,
                 "tls": false,
-                "manual": false
+                "manual": false,
+                "m6passthrough": false
             },
             "plugins": {
                 "allowPriorityReordering": false


### PR DESCRIPTION
Needed when using firmware M6 macros/plugins that interfere or supersede ncSender's built in tool change logic

There are already a couple of toolchanger plugins but even without a plugin ncSender will intercept and modify M6 commands (e.g. add return to original position, skip the command entirely if the tool numbers are the same). I couldn't find any way to turn this off and it caused tool changes to get stuck or fail in my setup.

If I'm using fluidnc's atc_manual plugin or my own M6 macro configured in the firmware, I believe also if you are using grblhal's semi-automatic toolchange features these can overlap or interfere with what ncSender tries to do.

In my use case, atc_manual in fluidnc takes care of moving above the tool setter, prompting to swap tools, probing the new tool, updating TLO, and moving back to the original position. ncSender appends a move to original position command to the M6 command which times out immediately (recent change to 1 second command timeouts I think is the culprit as a manual tool change can take a minute or more), it also puts the program in "tool change" mode which locks out all controls until the sentinel message is seen (MSG, TOOL_CHANGE_COMPLETE). Because the move to original position command timed out right away, the sentinel is never sent that releases the program from tool change mode. I can type it into the console directly to release it.
This is a bug that could be fixed on its own, but I would prefer an option to just have M6 commands passed through without any modification by ncSender. 

This PR adds a setting for M6 passthrough. It is false by default to not change existing behavior.
The changes to CommandProcessor add checks that the new m6passthrough setting is false before modifying or appending additional commands to parsed M6 commands. The intended result is an M6 command is passed through to the controller without any interference by the sender so the controller can fully handle the tool change on its own.

I'm not familiar with the UI side so this PR doesn't include the needed changes to the settings screen to be able to turn it on and off. For testing I updated my settings.json directly and I figured if you were interested, you'd have a better idea where in the UI to put it.